### PR TITLE
 solve issue #3

### DIFF
--- a/include/ent.h
+++ b/include/ent.h
@@ -30,25 +30,26 @@ extern std::vector<ent_t> g_mapents;
 // this stores all the ents that should be passed to the mod (g_mapents +/- modifications)
 extern std::vector<ent_t> g_modents;
 
-// this stores all info for entities that should be replaced
-// nodes are read and removed from this list when a "with" entity is found
-extern std::vector<ent_t> g_replaceents;
-
 #if defined(GAME_HAS_SPAWNENTS)
 // generate an entstring to pass to the mod
 const char* ents_generate_entstring(std::vector<ent_t>& list);
 #else
 // passes the next entity token to the mod
-intptr_t ent_next_token(char* buf, intptr_t len);
-#endif
+intptr_t ent_next_token(std::vector<ent_t>& list, char* buf, intptr_t len);
+#endif 
 
 // gets all the entity tokens from the engine
-void ents_load_tokens(std::vector<ent_t>& list);
+void ents_load_tokens(std::vector<ent_t>& list, std::vector<std::string> entstring_tokens = {});
 
 // outputs ent list to a file
 void ents_dump_to_file(std::vector<ent_t>& list, std::string file);
 
 // load and parse config file
-void ent_load_config(std::string file);
+void ent_load_config(std::vector<ent_t>& list, std::string file);
+
+#if defined(GAME_JASP)
+// tokenize an entstring into a vector of strings 
+std::vector<std::string> ent_parse_entstring(std::string entstring);
+#endif // GAME_JASP
 
 #endif // __STRIPPER_QMM_ENT_H__

--- a/include/game.h
+++ b/include/game.h
@@ -28,14 +28,12 @@ Created By:
     #define GAME_HAS_SPAWNENTS
 #elif defined(GAME_JAMP)
     #include <jamp/game/g_local.h>
-    #define GAME_HAS_SUBBSP
 #elif defined(GAME_JASP)
     #include <jasp/game/q_shared.h>
     #include <jasp/game/g_local.h>
     #include <jasp/game/bg_public.h>
     #include <game_jasp.h>
     #define GAME_HAS_SPAWNENTS
-    // #define GAME_HAS_SUBBSP  // see second big comment in QMM_syscall_Post
 #elif defined(GAME_WET)
     #include <wet/game/g_local.h>
 #elif defined(GAME_STVOYHM)


### PR DESCRIPTION
few changes to resolve:
- moved common init loading code to s_load_and_modify_ents() to clean up
- added cmd == G_SET_ACTIVE_SUBBSP section (for GAME_JASP only) to QMM_syscall to intercept, modify, and return subbsp entstring to mod
- ent_load_config now takes a list to use to store entities into
- ent_next_token now takes a list to use to return a token from (will be needed later for JAMP use, issue #2)
- add ent_parse_entstring from QMM to parse entstring into vector of token strings
- ents_load_tokens now takes an optional vector of strings to use for tokens instead of calling G_GET_ENTITY_TOKEN